### PR TITLE
Add stereo vision functionality

### DIFF
--- a/main-ceju-pyqt.py
+++ b/main-ceju-pyqt.py
@@ -12,6 +12,7 @@ import torch.backends.cudnn as cudnn
 import os
 import time
 import cv2
+import pyrealsense2 as rs
 from pathlib import Path
 
 from models.experimental import attempt_load

--- a/stereo/dianyuntu_yolo.py
+++ b/stereo/dianyuntu_yolo.py
@@ -174,8 +174,3 @@ def hw3ToN3(points):
     points_ = np.hstack((points_1, points_2, points_3))
 
     return points_
-
-
-
-
-


### PR DESCRIPTION
Add import for `pyrealsense2` in `main-ceju-pyqt.py`.

* Import `pyrealsense2` in `main-ceju-pyqt.py` to enable RealSense camera functionality.
* Remove unnecessary blank lines in `stereo/dianyuntu_yolo.py`.

